### PR TITLE
fixed Hysteric Assault (Siren) not showing up (drain based attack)

### DIFF
--- a/Skillchains.lua
+++ b/Skillchains.lua
@@ -47,7 +47,7 @@ default.display = {text={size=12,font='Consolas'},pos={x=0,y=0},bg={visible=true
 settings = config.load(default)
 skill_props = texts.new('',settings.display,settings)
 aeonic_ids = S{20515,20594,20695,20843,20890,20935,20977,21025,21082,21147,21485,21694,21753,22117}
-message_ids = S{2,110,161,162,185,187,317}
+message_ids = S{2,110,161,162,185,187,317,802}
 buff_dur = {[163]=40,[164]=30,[470]=60}
 pet_commands = {[110]=true,[317]=true}
 info = {member = {}}


### PR DESCRIPTION
Hysteric Assault was not being detected because its message reads as "...HP drained from..." instead of normal damage. This message ID seems to be 802. Added it to the list of message IDs and it seems to work. 
Not sure about possible side effects of this change...